### PR TITLE
Updates openshift cicd module to fix timing issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 
 module "openshift_cicd" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-openshift-cicd.git?ref=v1.7.10"
+  source = "github.com/cloud-native-toolkit/terraform-tools-openshift-cicd.git?ref=v1.7.11"
 
   cluster_type        = var.cluster_type
   ingress_subdomain   = var.ingress_subdomain
@@ -16,6 +16,7 @@ module "bootstrap" {
 
   cluster_config_file = var.cluster_config_file
   gitops_namespace    = module.openshift_cicd.argocd_namespace
+  kubeseal_namespace  = module.openshift_cicd.sealed_secrets_namespace
   sealed_secret_cert  = var.sealed_secret_cert
   sealed_secret_private_key = var.sealed_secret_private_key
   gitops_repo_url     = var.gitops_repo_url


### PR DESCRIPTION
- Updates openshift_cicd submodule to v1.7.11
- Passes sealed_secrets_namespace output from openshift_cicd to gitops-bootstrap module input

Closes #10

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>