### PR TITLE
Fixes issue with gitops repo credentials not added to ArgoCD

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "openshift_cicd" {
 }
 
 module "bootstrap" {
-  source = "github.com/cloud-native-toolkit/terraform-util-gitops-bootstrap.git?ref=v1.2.10"
+  source = "github.com/cloud-native-toolkit/terraform-util-gitops-bootstrap.git?ref=v1.2.11"
 
   cluster_config_file = var.cluster_config_file
   gitops_namespace    = module.openshift_cicd.argocd_namespace


### PR DESCRIPTION
- Upgrades gitops-bootstrap submodule to v1.2.11 to get update for handling of gitops repo credentials

closes #34

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>